### PR TITLE
Add missing dependency on Try::Tiny

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -13,6 +13,7 @@ my $build = Module::Build->new(
 		# This is a nasty hack so that XML::LibXML doesn't automatically pull
 		# the latest version that hates all reasonable versions of libxml2.
 		'XML::LibXML' => '< 2.0017',
+		'Try::Tiny' => 0.12,
 	},
 
 	recommends => {


### PR DESCRIPTION
On my system, Try::Tiny was not installed and not pulled in as a dependency. I've added it explicitly, so the `perl Build.PL` step will report this.
