### PR TITLE
add ::PP to namespace to reflect pure perl implementation

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -2,7 +2,7 @@ use Module::Build;
 # See perldoc Module::Build for details of how this works
 
 my $build = Module::Build->new(
-	module_name     => 'Net::AMQP::RabbitMQ',
+	module_name     => 'Net::AMQP::RabbitMQ::PP',
 	license         => 'perl',
 	dist_abstract   => "Pure perl AMQP client for RabbitMQ",
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -4,7 +4,7 @@ LICENSE
 MANIFEST
 README.md
 Todo
-lib/Net/AMQP/RabbitMQ.pm
+lib/Net/AMQP/RabbitMQ/PP.pm
 share/amqp0-9-1.extended.xml
 t/001_declare_exchange.t
 t/001_load.t

--- a/META.json
+++ b/META.json
@@ -12,7 +12,7 @@
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
       "version" : "2"
    },
-   "name" : "Net-AMQP-RabbitMQ",
+   "name" : "Net-AMQP-RabbitMQ-PP",
    "prereqs" : {
       "build" : {
          "requires" : {
@@ -36,8 +36,8 @@
       }
    },
    "provides" : {
-      "Net::AMQP::RabbitMQ" : {
-         "file" : "lib/Net/AMQP/RabbitMQ.pm",
+      "Net::AMQP::RabbitMQ::PP" : {
+         "file" : "lib/Net/AMQP/RabbitMQ/PP.pm",
          "version" : "0.01"
       }
    },

--- a/META.yml
+++ b/META.yml
@@ -12,10 +12,10 @@ license: perl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
   version: 1.4
-name: Net-AMQP-RabbitMQ
+name: Net-AMQP-RabbitMQ-PP
 provides:
-  Net::AMQP::RabbitMQ:
-    file: lib/Net/AMQP/RabbitMQ.pm
+  Net::AMQP::RabbitMQ::PP:
+    file: lib/Net/AMQP/RabbitMQ/PP.pm
     version: 0.01
 recommends:
   Socket::Linux: 0.01

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Net::AMQP::RabbitMQ
+Net::AMQP::RabbitMQ::PP
 ---------------
 
 # Build

--- a/lib/Net/AMQP/RabbitMQ/PP.pm
+++ b/lib/Net/AMQP/RabbitMQ/PP.pm
@@ -1,4 +1,4 @@
-package Net::AMQP::RabbitMQ;
+package Net::AMQP::RabbitMQ::PP;
 
 use strict;
 use warnings;
@@ -24,7 +24,7 @@ sub new {
 	if( ! %Net::AMQP::Protocol::spec ) {
 		Net::AMQP::Protocol->load_xml_spec(
 			File::ShareDir::dist_file(
-				'Net-AMQP-RabbitMQ',
+				'Net-AMQP-RabbitMQ-PP',
 				'amqp0-9-1.extended.xml'
 			)
 		);
@@ -889,13 +889,13 @@ __END__
 
 =head1 NAME
 
-Net::AMQP::RabbitMQ - Perl-based RabbitMQ AMQP client
+Net::AMQP::RabbitMQ::PP - Perl-based RabbitMQ AMQP client
 
 =head1 SYNOPSIS
 
-    use Net::AMQP::RabbitMQ;
+    use Net::AMQP::RabbitMQ::PP;
 
-    my $connection = Net::AMQP::RabbitMQ->new();
+    my $connection = Net::AMQP::RabbitMQ::PP->new();
     $connection->connect;
     $connection->basic_publish(
         payload => "Foo",

--- a/t/001_declare_exchange.t
+++ b/t/001_declare_exchange.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
 
-use_ok( 'Net::AMQP::RabbitMQ' );
+use_ok( 'Net::AMQP::RabbitMQ::PP' );
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/001_load.t
+++ b/t/001_load.t
@@ -4,8 +4,8 @@
 
 use Test::More tests => 2;
 
-use_ok( 'Net::AMQP::RabbitMQ' );
+use_ok( 'Net::AMQP::RabbitMQ::PP' );
 
-isa_ok( my $object = Net::AMQP::RabbitMQ->new (), 'Net::AMQP::RabbitMQ');
+isa_ok( my $object = Net::AMQP::RabbitMQ::PP->new (), 'Net::AMQP::RabbitMQ::PP');
 
 

--- a/t/002_publish.t
+++ b/t/002_publish.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/003_consume.t
+++ b/t/003_consume.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
 
-use_ok( 'Net::AMQP::RabbitMQ' );
+use_ok( 'Net::AMQP::RabbitMQ::PP' );
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/004_selfconsume.t
+++ b/t/004_selfconsume.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
 
-use_ok( 'Net::AMQP::RabbitMQ' );
+use_ok( 'Net::AMQP::RabbitMQ::PP' );
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/005_noack.t
+++ b/t/005_noack.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/006_txn.t
+++ b/t/006_txn.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/007_get.t
+++ b/t/007_get.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/008_queue_declare.t
+++ b/t/008_queue_declare.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/009_no_route.t
+++ b/t/009_no_route.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/010_qos.t
+++ b/t/010_qos.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/011_hearbeat.t
+++ b/t/011_hearbeat.t
@@ -7,9 +7,9 @@ use warnings;
 use Time::HiRes;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/012_timeout.t
+++ b/t/012_timeout.t
@@ -7,9 +7,9 @@ use strict;
 use warnings;
 
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new()) ;
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new()) ;
 
 local $SIG{ALRM} = sub { die "failed to timeout\n" };
 

--- a/t/013_headers.t
+++ b/t/013_headers.t
@@ -5,9 +5,9 @@ use warnings;
 
 my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/014_bind_with_headers.t
+++ b/t/014_bind_with_headers.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/015_declare_queue_with_headers.t
+++ b/t/015_declare_queue_with_headers.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new(), "Created object" );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new(), "Created object" );
 
 lives_ok {
 	$mq->connect(

--- a/t/016_reject.t
+++ b/t/016_reject.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/017_queue_delete.t
+++ b/t/017_queue_delete.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new(), 'new' );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new(), 'new' );
 
 lives_ok {
 	$mq->connect(

--- a/t/018_cancel.t
+++ b/t/018_cancel.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new(), 'new' );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new(), 'new' );
 
 lives_ok {
 	$mq->connect(

--- a/t/019_consumer_cancel.t
+++ b/t/019_consumer_cancel.t
@@ -6,12 +6,12 @@ use warnings;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
 SKIP: {
 	skip "Don't have boolean values", 9, unless Net::AMQP::Common->can("true");
 
-	ok( my $mq = Net::AMQP::RabbitMQ->new() );
+	ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 	lives_ok {
 		$mq->connect(
@@ -55,7 +55,7 @@ SKIP: {
 	} 'basic cancel callback';
 
 	lives_ok {
-		my $mq2 = Net::AMQP::RabbitMQ->new();
+		my $mq2 = Net::AMQP::RabbitMQ::PP->new();
 		$mq2->connect( host => $host, username => 'guest', password => 'guest' );
 
 		$mq2->channel_open(

--- a/t/020_bad_credentials.t
+++ b/t/020_bad_credentials.t
@@ -8,9 +8,9 @@ use warnings;
 
 my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new()) ;
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new()) ;
 
 local $SIG{ALRM} = sub { die "failed to timeout\n" };
 

--- a/t/021_read_timeout.t
+++ b/t/021_read_timeout.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
 
-use_ok( 'Net::AMQP::RabbitMQ' );
+use_ok( 'Net::AMQP::RabbitMQ::PP' );
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/022_close.t
+++ b/t/022_close.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
 
-use_ok('Net::AMQP::RabbitMQ');
+use_ok('Net::AMQP::RabbitMQ::PP');
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(

--- a/t/023_keepalive.t
+++ b/t/023_keepalive.t
@@ -10,9 +10,9 @@ SKIP: {
 
 	my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
 
-	use_ok('Net::AMQP::RabbitMQ');
+	use_ok('Net::AMQP::RabbitMQ::PP');
 
-	ok( my $mq = Net::AMQP::RabbitMQ->new() );
+	ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 	lives_ok {
 		$mq->connect(

--- a/t/024_exclusive_consume.t
+++ b/t/024_exclusive_consume.t
@@ -6,9 +6,9 @@ use warnings;
 
 my $host = $ENV{MQHOST} || "dev.rabbitmq.com";
 
-use_ok( 'Net::AMQP::RabbitMQ' );
+use_ok( 'Net::AMQP::RabbitMQ::PP' );
 
-ok( my $mq = Net::AMQP::RabbitMQ->new() );
+ok( my $mq = Net::AMQP::RabbitMQ::PP->new() );
 
 lives_ok {
 	$mq->connect(


### PR DESCRIPTION
this also avoids a clash with an existing module that has the same
namespace as this. this addresses:

https://github.com/emarcotte/net-amqp-rabbitmq/issues/15
